### PR TITLE
Changing the way IP is detected to support NAT scenario

### DIFF
--- a/plesk/setup
+++ b/plesk/setup
@@ -22,7 +22,7 @@ else
     # Initialize Plesk
    
     if [[ -z $ip ]]; then
-            ip=$(curl https://ipinfo.io/ip);
+            ip=$(plesk db -Ne 'SELECT IP_Address FROM IP_Addresses LIMIT 1');
     fi
      printf '{\n"status":"Configuring Plesk",\n"progress":"20"\n}' > /var/www/vhosts/default/htdocs/progress.json
     if [[ -n "$activation_key" ]]; then


### PR DESCRIPTION
The current way of fetching the IP is not working fine when server is behind NAT. 
Here is an example:

Server is behind NAT and is having IP 10.52.241.42:
```
# ip ro get 8.8.8.8
8.8.8.8 via 10.52.1.1 dev eth0 src 10.52.241.42 uid 0
```

When checking it with `curl https://ipinfo.io/ip` I will see my public IP:
```
curl https://ipinfo.io/ip
91.204.24.253
```

And then subscription create will fail with the following error as Plesk cannot create any web hosting configs on IP that does not exist within it (that was exactly my issue):
```
An error occurred during domain creation: IP address '91.204.24.253' does not exist
exit status 1
```

As we are creating subscription after init_conf is performed, Plesk has already detected all the IPs on the system so we can just select the first one from the database and create subscription using it.