### PR TITLE
Removing hostname variable and some unnecessary Plesk utilities calls

### DIFF
--- a/plesk/setup
+++ b/plesk/setup
@@ -1,7 +1,7 @@
 #!/bin/bash
-echo "Lets start" 
+echo "Lets start"
 . /root/config.ini
-# expected variables from the sourced file located at /root/config
+# expected variables from the sourced file located at /root/config.ini
 # domain - domain to create subscription for 
 # rootmail - root mail to be used by plesk
 # user - user used for the subscription
@@ -12,7 +12,6 @@ echo "Lets start"
 
 FILE=/etc/plesk
 if test -f "$FILE"; then
-    echo "Nothing to do here. PLESK seems to be already insalled"
     echo "Seems like everything was already done" 
 else 
     printf '{\n"status":"Waiting for VM",\n"progress":"0"\n}' > /var/www/vhosts/default/htdocs/progress.json
@@ -22,67 +21,55 @@ else
     # Initialize Plesk
    
     if [[ -z $ip ]]; then
-            ip=$(plesk db -Ne 'SELECT IP_Address FROM IP_Addresses LIMIT 1');
+        ip=$(plesk db -Ne 'SELECT IP_Address FROM IP_Addresses LIMIT 1');
     fi
-     printf '{\n"status":"Configuring Plesk",\n"progress":"20"\n}' > /var/www/vhosts/default/htdocs/progress.json
+    printf '{\n"status":"Configuring Plesk",\n"progress":"20"\n}' > /var/www/vhosts/default/htdocs/progress.json
     if [[ -n "$activation_key" ]]; then
         echo "Initialize Plesk" 
         printf '{\n"status":"Initialize Plesk",\n"progress":"5"\n}' > /var/www/vhosts/default/htdocs/progress.json
-        plesk bin init_conf --init -hostname $domain -name $user -passwd $passwd -email $rootmail -license_agreed true 
-        plesk bin extension -g letsencrypt
-        plesk bin license --install $activation_key 
+        plesk bin init_conf --init -name $user -passwd $passwd -email $rootmail -license_agreed true
+        plesk bin license --install $activation_key
 
         # Setting up the subscription inside plesk
-	    echo "Setting up the subscription inside plesk"
-        plesk bin subscription --create $domain -owner admin -service-plan "UNLIMITED" -login ${user,,} -passwd $passwd -ip $ip 
+        echo "Setting up the subscription inside plesk"
+        plesk bin subscription --create $domain -owner admin -service-plan "UNLIMITED" -login ${user,,} -passwd $passwd -ip $ip
         OUT=$?
+
         # Check if Subscription was created without errors
-	    echo "Check if Subscription was created without errors" 
-        if [ $OUT -ne 0 ];then
-        printf '{\n"status":"Error while creating the  Subscription",\n"progress":"100"\n}' > /var/www/vhosts/default/htdocs/progress.json
-        echo
-        echo "An error occurred! The setup of Plesk failed. Please see logged lines above for error handling!"
-        exit 1
-         fi
+        echo "Check if Subscription was created without errors"
+        if [ "$OUT" -ne 0 ]; then
+            printf '{\n"status":"Error while creating the  Subscription",\n"progress":"100"\n}' > /var/www/vhosts/default/htdocs/progress.json
+            echo "An error occurred! The setup of Plesk failed. Please see logged lines above for error handling!"
+            exit 1
+        fi
     else
-        echo "Initialize Plesk" 
-         printf '{\n"status":"Initialize Plesk",\n"progress":"5"\n}' > /var/www/vhosts/default/htdocs/progress.json
-         plesk bin init_conf --init -hostname $domain -name $user -passwd $passwd -email $rootmail -license_agreed true -trial_license true
-         plesk bin extension -g letsencrypt
+        echo "Initialize Plesk"
+        printf '{\n"status":"Initialize Plesk",\n"progress":"5"\n}' > /var/www/vhosts/default/htdocs/progress.json
+        plesk bin init_conf --init -name $user -passwd $passwd -email $rootmail -license_agreed true -trial_license true
+
         # Setting up the subscription inside plesk
-	    echo "Setting up the subscription inside plesk"
-        plesk bin subscription --create $domain -owner admin -service-plan "UNLIMITED" -login ${user,,} -passwd $passwd -ip $ip 
+        echo "Setting up the subscription inside plesk"
+        plesk bin subscription --create $domain -owner admin -service-plan "UNLIMITED" -login ${user,,} -passwd $passwd -ip $ip
         OUT=$?
+
         # Check if Subscription was created without errors
-	    echo "Check if Subscription was created without errors" 
-        if [ $OUT -ne 0 ];then
-        printf '{\n"status":"Error while creating the  Subscription",\n"progress":"100"\n}' > /var/www/vhosts/default/htdocs/progress.json
-        echo "An error occurred! The setup of Plesk failed. Please see logged lines above for error handling!"
+        echo "Check if Subscription was created without errors"
+        if [ "$OUT" -ne 0 ]; then
+            printf '{\n"status":"Error while creating the  Subscription",\n"progress":"100"\n}' > /var/www/vhosts/default/htdocs/progress.json
+            echo "An error occurred! The setup of Plesk failed. Please see logged lines above for error handling!"
         exit 1
-         fi
+        fi
     fi
 
-    #securing Plesk with Let's Encrypt
-    plesk bin extension --exec letsencrypt cli.php -d $domain -m $rootmail --letsencrypt-plesk:plesk-secure-panel 
-
     # set solution type to identify servers
-	echo "set solution type to identify servers" 
-    plesk bin settings --set solution_type="solusIO"
- 
-   
+    echo "set solution type to identify servers"
+    plesk bin settings --set solution_type="SOLUSIO"
+
     printf '{\n"status":"Configuring Plesk",\n"progress":"50"\n}' > /var/www/vhosts/default/htdocs/progress.json
     plesk bin poweruser --on
-    
-    
- 
-    # Install the WordPress Toolkit
-    plesk bin extension --install wp-toolkit
-    	
-    printf '{\n"status":"Setting up Let´s Encrypt",\n"progress":"95"\n}' > /var/www/vhosts/default/htdocs/progress.json
-    plesk bin extension --exec letsencrypt cli.php -d $domain  -m $rootmail  
 
-   # Activate all recommendations
-    plesk ext advisor --apply-recommendations
+    # Workaround for PPP-43353
+    plesk bin settings --set secure_passwords=true
 
     printf '{\n"status":"Everything is up and running",\n"progress":"100"\n}' > /var/www/vhosts/default/htdocs/progress.json
     echo "Installation done"


### PR DESCRIPTION
Here I am refactoring this one a little bit. I am doing some formatting fixes as well, so changes might be a bit hard to spot, so.

Сhanges:
1. No more unnecessary plesk bin extenstion calls to install let's encrypt and wordpress toolkit as we are working on 'recommended' preset of Plesk install and recommended preset has those installed already.
2. No more auto apply of Advisor recommendations: this process can be running for a while (like 40 minutes O_o) and doing almost nothing (for example, installing acronis backup :) ). No need to do that during initial setup.
3. No more `-hostname $domain` in init_conf as in case installation does not have any valid hostname, the technical domain hostname will be used, however if there is -hostname in init_conf it overrides technical domain possibly making login links broken.
4. No more calls to secure hostname with let's encrypt: as we are removing the hostname and using technical domain there, there is nothing to secure and no need to secure anything as technical domain is already secured.
5. Replaced 'solusIO' with SOLUSIO similar to https://github.com/plesk/solus-cloud-images/blob/public/scripts/plesk/install_plesk.sh#L158 
6. Added 'plesk bin settings --set secure_passwords=true' to workaround one Plesk bug (that is closed as 'cannot reproduce' however it can be reproduced here).